### PR TITLE
Fix a couple of simple typos in example codes.

### DIFF
--- a/examples/hitechnic-irseeker-v2-SMUX-test1.c
+++ b/examples/hitechnic-irseeker-v2-SMUX-test1.c
@@ -60,8 +60,8 @@ task main ()
     {
       // Read the sensor data.
       readSensor(&irSeeker);
-      displayTextLine(1, "D:%4d %4d 3%d", irSeeker.dcDirection, irSeeker.acDirection, irSeeker.enhDirection);
-      displayTextLine(2, "0:%4d %d", irSeeker.dcValues[0], irSeeker.acValues[0]);
+      displayTextLine(1, "D:%4d %4d %3d", irSeeker.dcDirection, irSeeker.acDirection, irSeeker.enhDirection);
+      displayTextLine(2, "0:%4d %4d", irSeeker.dcValues[0], irSeeker.acValues[0]);
       displayTextLine(3, "0:%4d %4d", irSeeker.dcValues[1], irSeeker.acValues[1]);
       displayTextLine(4, "0:%4d %4d %3d", irSeeker.dcValues[2], irSeeker.acValues[2], irSeeker.enhStrength);
       displayTextLine(5, "0:%4d %4d", irSeeker.dcValues[3], irSeeker.acValues[3]);

--- a/examples/hitechnic-irseeker-v2-test1.c
+++ b/examples/hitechnic-irseeker-v2-test1.c
@@ -73,8 +73,8 @@ task main ()
 
       // Read the sensor data.
       readSensor(&irSeeker);
-      displayTextLine(1, "D:%4d %4d 3%d", irSeeker.dcDirection, irSeeker.acDirection, irSeeker.enhDirection);
-      displayTextLine(2, "0:%4d %d", irSeeker.dcValues[0], irSeeker.acValues[0]);
+      displayTextLine(1, "D:%4d %4d %3d", irSeeker.dcDirection, irSeeker.acDirection, irSeeker.enhDirection);
+      displayTextLine(2, "0:%4d %4d", irSeeker.dcValues[0], irSeeker.acValues[0]);
       displayTextLine(3, "0:%4d %4d", irSeeker.dcValues[1], irSeeker.acValues[1]);
       displayTextLine(4, "0:%4d %4d %3d", irSeeker.dcValues[2], irSeeker.acValues[2], irSeeker.enhStrength);
       displayTextLine(5, "0:%4d %4d", irSeeker.dcValues[3], irSeeker.acValues[3]);


### PR DESCRIPTION
There were a couple of simple typos in the example codes for the HiTechnic IR Seeker V2, in formatting the output displays.  